### PR TITLE
don't parse property that doesn't exist in object.

### DIFF
--- a/KeyValueObjectMapping/DCReferenceKeyParser.m
+++ b/KeyValueObjectMapping/DCReferenceKeyParser.m
@@ -25,7 +25,7 @@
 }
 
 - (NSString *) splitKeyAndMakeCamelcased: (NSString *) key {
-    if(!key || [key isEqualToString:@""])
+    if(!key || [key isEqualToString:@""] || splitToken == nil)
         return @"";
     NSArray *splitedKeys = [key componentsSeparatedByString:splitToken];
     NSMutableString *parsedKeyName = [NSMutableString string];

--- a/KeyValueObjectMappingTests/DCReferenceKeyParserTests.m
+++ b/KeyValueObjectMappingTests/DCReferenceKeyParserTests.m
@@ -53,4 +53,14 @@
     STAssertEqualObjects(@"", emptyWordSplited, @"Should be empty NSString when the property name passed is an empty NSString");
 }
 
+- (void) testWithEmptyToken {
+    //this happen when you try parse witout config object and property doesn't exist.
+    /* example
+      DCKeyValueObjectMapping *parser = [DCKeyValueObjectMapping mapperForClass: [SomeClass class]  andConfiguration:nil];
+    */
+    parser = [DCReferenceKeyParser parserForToken:nil];
+    NSString *NotExistingProperty = @"id";
+    STAssertNoThrow([parser splitKeyAndMakeCamelcased:NotExistingProperty], @"shouldn't throw an exception");
+}
+
 @end


### PR DESCRIPTION
I had exception when tried to parse json with destination object that doesn't have some property.
Parser should skip not existing properties.

Example -
" {
    "id": "27924446",
    "name": "Diego Chohfi"
} "
@interface TestClass 
@property (nonatomic, strong) NSString *id;
// I don't want to parse name

 DCKeyValueObjectMapping *parser = [DCKeyValueObjectMapping mapperForClass: [TestClass class]  andConfiguration:nil];
    TestClass *test = [parser parseDictionary:jsData];
