### PR TITLE
Bugfix for DCValueConverter

### DIFF
--- a/KeyValueObjectMapping/DCValueConverter.h
+++ b/KeyValueObjectMapping/DCValueConverter.h
@@ -14,7 +14,7 @@
 
 - (id) transformValue:(id)value forDynamicAttribute:(DCDynamicAttribute *)attribute;
 - (id) serializeValue:(id)value forDynamicAttribute:(DCDynamicAttribute *)attribute;
-- (BOOL) canTransformValueForClass: (Class) class;
+- (BOOL) canTransformValueForClass: (Class)classe;
 
 
 @end


### PR DESCRIPTION
there was param name called "class" which is not allowed in Objective-C++
