### PR TITLE
Fixed potential bug in last commit

### DIFF
--- a/KeyValueObjectMapping/DCDictionaryRearranger.m
+++ b/KeyValueObjectMapping/DCDictionaryRearranger.m
@@ -39,11 +39,10 @@
                 if ([key isEqualToString:keys[0]]) {
                     value = [mutableDictionary objectForKey:key];
                 } else if ([value isKindOfClass:[NSDictionary class]]) {
-                    NSMutableDictionary* dict = [(NSDictionary*)value mutableCopy];
+                    NSDictionary* dict = (NSDictionary*)value;
                     value = [dict objectForKey:key];
                     if ([key isEqualToString:[keys lastObject]]) {
-                        [dict removeObjectForKey:key];
-                        [mutableDictionary setValue:value forKey:key];
+                        [mutableDictionary setValue:value forKey:mapper.keyReference];
                     }
                 }
             }


### PR DESCRIPTION
If an object key at the root of the JSON tree has the same name than the nested object key.
