### PR TITLE
Adding support for current object context in DCCustomParsers

### DIFF
--- a/KeyValueObjectMapping/DCCustomParser.h
+++ b/KeyValueObjectMapping/DCCustomParser.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-typedef id(^DCCustomParserBlock)(__weak NSString *attributeName, __weak Class destinationClass, __weak id value);
+typedef id(^DCCustomParserBlock)(__weak NSDictionary *dictionary, __weak NSString *attributeName, __weak Class destinationClass, __weak id value);
 
 @interface DCCustomParser : NSObject
 

--- a/KeyValueObjectMapping/DCGenericConverter.h
+++ b/KeyValueObjectMapping/DCGenericConverter.h
@@ -12,6 +12,6 @@
 
 @interface DCGenericConverter : NSObject
 - (id)initWithConfiguration:(DCParserConfiguration *) configuration;
-- (id)transformValue:(id)value forDynamicAttribute: (DCDynamicAttribute *) attribute;
+- (id)transformValue:(id)value forDynamicAttribute: (DCDynamicAttribute *) attribute dictionary:dictionary;
 - (id)serializeValue:(id)value forDynamicAttribute: (DCDynamicAttribute *) attribute;
 @end

--- a/KeyValueObjectMapping/DCKeyValueObjectMapping.m
+++ b/KeyValueObjectMapping/DCKeyValueObjectMapping.m
@@ -83,7 +83,7 @@
         DCDynamicAttribute *dynamicAttribute = [self.propertyFinder findAttributeForKey:key
                                                                                 onClass:self.classToGenerate];
         if(dynamicAttribute){
-            [self parseValue:value forObject:object inAttribute:dynamicAttribute];
+            [self parseValue:value forObject:object inAttribute:dynamicAttribute dictionary:dictionary];
         }
     }
 }
@@ -117,14 +117,17 @@
 }
 - (void) parseValue: (id) value
           forObject: (id) object
-        inAttribute: (DCDynamicAttribute *) dynamicAttribute {
+        inAttribute: (DCDynamicAttribute *) dynamicAttribute
+         dictionary: (NSDictionary *) dictionary {
     DCObjectMapping *objectMapping = dynamicAttribute.objectMapping;
     NSString *attributeName = objectMapping.attributeName;
 
-    if (objectMapping.converter)
-        value = [objectMapping.converter transformValue:value forDynamicAttribute:dynamicAttribute];
-    else
-        value = [self.converter transformValue:value forDynamicAttribute:dynamicAttribute];
+    if (objectMapping.converter) {
+        value = [objectMapping.converter transformValue:value forDynamicAttribute:dynamicAttribute dictionary:dictionary];
+    }
+    else {
+        value = [self.converter transformValue:value forDynamicAttribute:dynamicAttribute dictionary:dictionary];
+    }
 
     [DCAttributeSetter assingValue:value 
                   forAttributeName:attributeName 

--- a/KeyValueObjectMapping/DCNSArrayConverter.m
+++ b/KeyValueObjectMapping/DCNSArrayConverter.m
@@ -33,14 +33,14 @@
     return self;   
 }
 
-- (id)transformValue:(id)values forDynamicAttribute:(DCDynamicAttribute *)attribute {
+- (id)transformValue:(id)values forDynamicAttribute:(DCDynamicAttribute *)attribute dictionary:(NSDictionary *)dictionary {
     if(!values || values == [NSNull null] || [values count] == 0){
         return nil;
     }
     
     BOOL primitiveArray = ![[[values objectAtIndex:0] class] isSubclassOfClass:[NSDictionary class]];
     if(primitiveArray){
-        return [self parsePrimitiveValues:values];
+        return [self parsePrimitiveValues:values dictionary:dictionary];
     }else{
         DCArrayMapping *mapper = [self.configuration arrayMapperForMapper:attribute.objectMapping];
         if(mapper){
@@ -59,12 +59,12 @@
     }    
     return [NSArray arrayWithArray:valuesHolder];
 }
-- (NSArray *) parsePrimitiveValues: (NSArray *) primitiveValues {
+- (NSArray *) parsePrimitiveValues: (NSArray *) primitiveValues dictionary:(NSDictionary *)dictionary {
     DCSimpleConverter *simpleParser = [[DCSimpleConverter alloc] init];
     NSMutableArray *valuesHolder = [NSMutableArray array];
     for(id value in primitiveValues){
         DCDynamicAttribute *valueClassAsAttribute = [[DCDynamicAttribute alloc] initWithClass:[value class]];
-        [valuesHolder addObject:[simpleParser transformValue:value forDynamicAttribute:valueClassAsAttribute]];
+        [valuesHolder addObject:[simpleParser transformValue:value forDynamicAttribute:valueClassAsAttribute dictionary:dictionary]];
     }
     return [NSArray arrayWithArray:valuesHolder];
 }

--- a/KeyValueObjectMapping/DCNSDateConverter.m
+++ b/KeyValueObjectMapping/DCNSDateConverter.m
@@ -27,7 +27,7 @@
     }
     return self;
 }
-- (id)transformValue:(id)value forDynamicAttribute:(DCDynamicAttribute *)attribute {
+- (id)transformValue:(id)value forDynamicAttribute:(DCDynamicAttribute *)attribute dictionary:(NSDictionary *)dictionary {
     BOOL validDouble = [self validDouble:[NSString stringWithFormat:@"%@", value]];
     if(validDouble){
         return [NSDate dateWithTimeIntervalSince1970:[value doubleValue]];

--- a/KeyValueObjectMapping/DCNSSetConverter.m
+++ b/KeyValueObjectMapping/DCNSSetConverter.m
@@ -31,8 +31,8 @@
     return self;
 }
 
-- (id)transformValue:(id)values forDynamicAttribute:(DCDynamicAttribute *)attribute {
-    NSArray *result = [self.arrayConverter transformValue:values forDynamicAttribute:attribute];
+- (id)transformValue:(id)values forDynamicAttribute:(DCDynamicAttribute *)attribute dictionary:(NSDictionary *)dictionary {
+    NSArray *result = [self.arrayConverter transformValue:values forDynamicAttribute:attribute dictionary:dictionary];
     return [NSSet setWithArray:result];
 }
 

--- a/KeyValueObjectMapping/DCNSURLConverter.m
+++ b/KeyValueObjectMapping/DCNSURLConverter.m
@@ -14,7 +14,7 @@
     return [[self alloc] init];
 }
 
-- (id)transformValue:(id)value forDynamicAttribute:(DCDynamicAttribute *)attribute {
+- (id)transformValue:(id)value forDynamicAttribute:(DCDynamicAttribute *)attribute dictionary:(NSDictionary *)dictionary {
     return [NSURL URLWithString:value];
 }
 - (id)serializeValue:(id)value forDynamicAttribute:(DCDynamicAttribute *)attribute {

--- a/KeyValueObjectMapping/DCPropertyFinder.m
+++ b/KeyValueObjectMapping/DCPropertyFinder.m
@@ -44,17 +44,20 @@
         return nil;
 
     DCDynamicAttribute *dynamicAttribute;
-    if (mapper && mapper.converter)
+    if (mapper && mapper.converter) {
         dynamicAttribute = [[DCDynamicAttribute alloc] initWithAttributeDescription:propertyDetails
                                                                              forKey:originalKey
                                                                             onClass:class
                                                                       attributeName:key
                                                                           converter:mapper.converter];
-    else
+    }
+    else {
         dynamicAttribute = [[DCDynamicAttribute alloc] initWithAttributeDescription:propertyDetails
                                                                              forKey:originalKey
                                                                             onClass:class
                                                                       attributeName:key];
+    }
+
     return dynamicAttribute;
 }
 

--- a/KeyValueObjectMapping/DCSimpleConverter.m
+++ b/KeyValueObjectMapping/DCSimpleConverter.m
@@ -9,7 +9,7 @@
 #import "DCSimpleConverter.h"
 
 @implementation DCSimpleConverter
-- (id)transformValue:(id)value forDynamicAttribute:(DCDynamicAttribute *)attribute {
+- (id)transformValue:(id)value forDynamicAttribute:(DCDynamicAttribute *)attribute dictionary:(NSDictionary *)dictionary {
     return value;
 }
 -(id)serializeValue:(id)value forDynamicAttribute:(DCDynamicAttribute *)attribute{

--- a/KeyValueObjectMapping/DCValueConverter.h
+++ b/KeyValueObjectMapping/DCValueConverter.h
@@ -12,7 +12,7 @@
 
 @protocol DCValueConverter <NSObject>
 
-- (id) transformValue:(id)value forDynamicAttribute:(DCDynamicAttribute *)attribute;
+- (id) transformValue:(id)value forDynamicAttribute:(DCDynamicAttribute *)attribute dictionary:(NSDictionary *)dictionary;
 - (id) serializeValue:(id)value forDynamicAttribute:(DCDynamicAttribute *)attribute;
 - (BOOL) canTransformValueForClass: (Class)classe;
 


### PR DESCRIPTION
Hi,

In custom parser we don't have any information about the current object (dictionary) being processed. I modified master from last commit to add the current object context (the dictionary) in the DCCustomParserBlock.

By this add, you can leverage other params from the same object (dictionary) to decide how you have to parse the current attribute being processed.

Some example: 

```
DCParserConfiguration *config = [[DCParserConfiguration alloc] init];

...

DCCustomParserBlock valueParserBlock = ^id(__weak NSDictionary *dictionary, NSString *__weak attributeName, __weak Class destinationClass, __weak id value) {
    id type = dictionary[@"type"];
    if ([type isEqualToString:@"brand"]) {
        return [XBMapper parseObject:value intoObjectsOfType:LCBrand.class];
    }
    else if ([@[@"category", @"option"] containsObject: type]) {
        NSMutableIndexSet *indexSet = [NSMutableIndexSet indexSet];
        for (NSNumber *item in value) {
            [indexSet addIndex:(NSUInteger)item.integerValue];
        }
        return indexSet;
    }
    else {
        return value;
    }
};

DCCustomParser *valueParser = [[DCCustomParser alloc] initWithBlockParser:valueParserBlock
                                                         forAttributeName:@"_value"
                                                       onDestinationClass:[self class]];
[config addCustomParsersObject:valueParser];

return config;
```
