### PR TITLE
Change parameter name class because it uses in c++

### DIFF
--- a/KeyValueObjectMapping/DCNSDateConverter.m
+++ b/KeyValueObjectMapping/DCNSDateConverter.m
@@ -45,8 +45,8 @@
     formatter.dateFormat = self.pattern;
     return [formatter stringFromDate:value];    
 }
-- (BOOL)canTransformValueForClass: (Class) class {
-    return [class isSubclassOfClass:[NSDate class]];
+- (BOOL)canTransformValueForClass: (Class) cls {
+    return [cls isSubclassOfClass:[NSDate class]];
 }
 - (BOOL) validDouble: (NSString *) doubleValue {
   return [[[NSNumberFormatter alloc] init] numberFromString:doubleValue] != nil;

--- a/KeyValueObjectMapping/DCNSURLConverter.m
+++ b/KeyValueObjectMapping/DCNSURLConverter.m
@@ -21,8 +21,8 @@
 - (id)serializeValue:(id)value forDynamicAttribute:(DCDynamicAttribute *)attribute {
     return [((NSURL *)value) absoluteString];
 }
-- (BOOL)canTransformValueForClass: (Class) class {
-    return [class isSubclassOfClass:[NSURL class]];
+- (BOOL)canTransformValueForClass: (Class) cls {
+    return [cls isSubclassOfClass:[NSURL class]];
 }
 
 @end

--- a/KeyValueObjectMapping/DCPropertyFinder.m
+++ b/KeyValueObjectMapping/DCPropertyFinder.m
@@ -25,19 +25,19 @@
     return [[self alloc] initWithKeyParser:_keyParser];
 }
 
-- (DCDynamicAttribute *) findAttributeForKey: (NSString *) key onClass: (Class) class {
+- (DCDynamicAttribute *) findAttributeForKey: (NSString *) key onClass: (Class) cls {
     NSString *originalKey = key;
     
-    DCObjectMapping *mapper = [self findMapperForKey:key onClass:class];
+    DCObjectMapping *mapper = [self findMapperForKey:key onClass:cls];
     
     if(mapper){
         key = mapper.attributeName;
     }
     
-    NSString *propertyDetails = [self findPropertyDetailsForKey:key onClass:class];
+    NSString *propertyDetails = [self findPropertyDetailsForKey:key onClass:cls];
     if(!propertyDetails){
         key = [self.keyParser splitKeyAndMakeCamelcased:key];
-        propertyDetails = [self findPropertyDetailsForKey:key onClass:class];
+        propertyDetails = [self findPropertyDetailsForKey:key onClass:cls];
     }
     
     if(!propertyDetails)
@@ -47,14 +47,14 @@
     if (mapper && mapper.converter) {
         dynamicAttribute = [[DCDynamicAttribute alloc] initWithAttributeDescription:propertyDetails
                                                                              forKey:originalKey
-                                                                            onClass:class
+                                                                            onClass:cls
                                                                       attributeName:key
                                                                           converter:mapper.converter];
     }
     else {
         dynamicAttribute = [[DCDynamicAttribute alloc] initWithAttributeDescription:propertyDetails
                                                                              forKey:originalKey
-                                                                            onClass:class
+                                                                            onClass:cls
                                                                       attributeName:key];
     }
 
@@ -84,9 +84,9 @@
     return nil;
 }
 
-- (DCObjectMapping *) findMapperForKey: (NSString *) key onClass: (Class) class {
+- (DCObjectMapping *) findMapperForKey: (NSString *) key onClass: (Class) cls {
     for(DCObjectMapping *mapper in self.mappers){
-        if([mapper sameKey:key andClassReference:class]){
+        if([mapper sameKey:key andClassReference:cls]){
             return mapper;
         }
     }

--- a/KeyValueObjectMapping/DCValueConverter.h
+++ b/KeyValueObjectMapping/DCValueConverter.h
@@ -15,6 +15,6 @@
 @required
 - (id)transformValue:(id)value forDynamicAttribute:(DCDynamicAttribute *)attribute dictionary:(NSDictionary *)dictionary parentObject:(id)parentObject;
 - (id)serializeValue:(id)value forDynamicAttribute:(DCDynamicAttribute *)attribute;
-- (BOOL)canTransformValueForClass:(Class)class;
+- (BOOL)canTransformValueForClass:(Class)cls;
 
 @end


### PR DESCRIPTION
When parameter name is class I can't compile .mm file(for example in Cedar tests) because name is reserved in c++.
