### PR TITLE
Added convenience method for adding multiple object mappings at once.

### DIFF
--- a/KeyValueObjectMapping/DCParserConfiguration.h
+++ b/KeyValueObjectMapping/DCParserConfiguration.h
@@ -23,6 +23,7 @@
 
 - (void) addArrayMapper: (DCArrayMapping *)mapper;
 - (void) addObjectMapping: (DCObjectMapping *) mapper;
+- (void) addObjectMappings: (NSArray *)mappers;
 - (void) addAggregator: (DCPropertyAggregator *) aggregator;
 - (void) addCustomInitializersObject:(DCCustomInitialize *) customInitialize;
 - (void) addCustomParsersObject:(DCCustomParser *)parser;

--- a/KeyValueObjectMapping/DCParserConfiguration.m
+++ b/KeyValueObjectMapping/DCParserConfiguration.m
@@ -61,6 +61,11 @@
 - (void) addObjectMapping: (DCObjectMapping *) mapper {
     [self.objectMappers addObject:mapper];
 }
+- (void) addObjectMappings: (NSArray *)mappers {
+    for (DCObjectMapping *mapper in mappers) {
+        [self.objectMappers addObject:mapper];
+    }
+}
 - (void) addAggregator: (DCPropertyAggregator *) aggregator {
     [self.aggregators addObject:aggregator];
 }


### PR DESCRIPTION
A convenience method for adding multiple DCObjectMappings. 

So:

```
DCObjectMapping *idMapping = [DCObjectMapping mapKeyPath:@"id" toAttribute:@"externalId" onClass:[TCBCustomer class]];
DCObjectMapping *nameMapping = [DCObjectMapping mapKeyPath:@"name" toAttribute:@"customerName" onClass:[TCBCustomer class]];
DCObjectMapping *phoneMapping = [DCObjectMapping mapKeyPath:@"phone" toAttribute:@"customerPhone" onClass:[TCBCustomer class]];
DCObjectMapping *emailMapping = [DCObjectMapping mapKeyPath:@"email" toAttribute:@"customerEmail" onClass:[TCBCustomer class]];
[config addObjectMapping:idMapping];
[config addObjectMapping:nameMapping];
[config addObjectMapping:phoneMapping];
[config addObjectMapping:emailMapping];
```

Becomes:

```
DCObjectMapping *idMapping = [DCObjectMapping mapKeyPath:@"id" toAttribute:@"externalId" onClass:[TCBCustomer class]];
DCObjectMapping *nameMapping = [DCObjectMapping mapKeyPath:@"name" toAttribute:@"customerName" onClass:[TCBCustomer class]];
DCObjectMapping *phoneMapping = [DCObjectMapping mapKeyPath:@"phone" toAttribute:@"customerPhone" onClass:[TCBCustomer class]];
DCObjectMapping *emailMapping = [DCObjectMapping mapKeyPath:@"email" toAttribute:@"customerEmail" onClass:[TCBCustomer class]];
[config addObjectMappings:@[idMapping, nameMapping, phoneMapping, emailMapping]];
```
