### PR TITLE
Locate in parser configuration

### DIFF
--- a/KeyValueObjectMapping/DCGenericConverter.m
+++ b/KeyValueObjectMapping/DCGenericConverter.m
@@ -29,7 +29,7 @@
     if (self) {
         _configuration = configuration;
         _parsers = [NSArray arrayWithObjects:
-                   [DCNSDateConverter dateConverterForPattern:self.configuration.datePattern],
+                   [DCNSDateConverter dateConverterForPattern:self.configuration.datePattern locale:self.configuration.dateLocale],
                    [DCNSURLConverter urlConverter],
                    [DCNSArrayConverter arrayConverterForConfiguration: self.configuration], 
                    [DCNSSetConverter setConverterForConfiguration: self.configuration], nil];

--- a/KeyValueObjectMapping/DCNSDateConverter.h
+++ b/KeyValueObjectMapping/DCNSDateConverter.h
@@ -10,6 +10,6 @@
 #import "DCValueConverter.h"
 @interface DCNSDateConverter : NSObject <DCValueConverter>
 
-+ (DCNSDateConverter *) dateConverterForPattern: (NSString *) pattern;
++ (DCNSDateConverter *) dateConverterForPattern: (NSString *) pattern locale:(NSLocale *)locale;
 
 @end

--- a/KeyValueObjectMapping/DCNSDateConverter.m
+++ b/KeyValueObjectMapping/DCNSDateConverter.m
@@ -11,6 +11,7 @@
 
 @interface DCNSDateConverter()
 @property(nonatomic, strong) NSString *pattern;
+@property(nonatomic, strong) NSLocale *locale;
 - (BOOL) validDouble: (NSString *) doubleValue;
 @end
 
@@ -18,14 +19,15 @@
 @synthesize pattern = _pattern;
 
 
-+ (DCNSDateConverter *) dateConverterForPattern: (NSString *) pattern{
-    return [[self alloc] initWithDatePattern: pattern];
++ (DCNSDateConverter *) dateConverterForPattern: (NSString *) pattern locale:(NSLocale *)locale {
+    return [[self alloc] initWithDatePattern: pattern locale:locale];
 }
 
-- (id) initWithDatePattern: (NSString *) pattern {
+- (id) initWithDatePattern: (NSString *) pattern locale:(NSLocale *)locale {
     self = [super init];
     if (self) {
         _pattern = pattern;
+        _locale = locale;
     }
     return self;
 }
@@ -37,13 +39,19 @@
     }else{
         NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
         formatter.dateFormat = self.pattern;
+        if (self.locale) {
+            formatter.locale = self.locale;
+        }
         return [formatter dateFromString:value];
     }
 }
 - (id)serializeValue:(id)value forDynamicAttribute:(DCDynamicAttribute *)attribute {
     NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
     formatter.dateFormat = self.pattern;
-    return [formatter stringFromDate:value];    
+    if (self.locale) {
+        formatter.locale = self.locale;
+    }
+    return [formatter stringFromDate:value];
 }
 - (BOOL)canTransformValueForClass: (Class) cls {
     return [cls isSubclassOfClass:[NSDate class]];

--- a/KeyValueObjectMapping/DCParserConfiguration.h
+++ b/KeyValueObjectMapping/DCParserConfiguration.h
@@ -12,6 +12,7 @@
 @interface DCParserConfiguration : NSObject
 
 @property(nonatomic, strong) NSString *datePattern;
+@property(nonatomic, strong) NSLocale *dateLocale;
 @property(nonatomic, strong) NSString *splitToken;
 @property(nonatomic, strong) NSString *nestedPrepertiesSplitToken;
 @property(nonatomic, readonly) NSMutableArray *objectMappers;

--- a/KeyValueObjectMappingTests/DCNSDateConverterTests.m
+++ b/KeyValueObjectMappingTests/DCNSDateConverterTests.m
@@ -16,7 +16,7 @@
 @implementation DCNSDateConverterTests
 
 - (void) testValidDouble {
-  DCNSDateConverter *convertor = [DCNSDateConverter dateConverterForPattern:@"yyyy'-'MM'-'dd'T'HH':'mm':'ss'Z'"];
+  DCNSDateConverter *convertor = [DCNSDateConverter dateConverterForPattern:@"yyyy'-'MM'-'dd'T'HH':'mm':'ss'Z'" locale:nil];
   STAssertTrue([convertor validDouble:@"10"], @"Should recognize '10' as a valid double");
   STAssertTrue([convertor validDouble:@"10.0"], @"Should recognize '10.0' as a valid double");
   [@[ @"Monday, April 17, 2006", @"Monday, April 17, 2006 2:22:48 PM", @"4/17/2006 2:22:48 PM", @"Mon, 17 Apr 2006 21:22:48 GMT", @"2006-04-17 21:22:48Z", @"2006-04-17T14:22:48.2698750-07:00" ]

--- a/KeyValueObjectMappingTests/KeyValueObjectMappingTests.m
+++ b/KeyValueObjectMappingTests/KeyValueObjectMappingTests.m
@@ -79,7 +79,7 @@
     STAssertEqualObjects(tweet.text, @"@pedroh96 cara, comecei uma lib pra iOS, se puder dar uma olhada e/ou contribuir :D KeyValue Parse for Objective-C https://t.co/NWMMc60v", @"Should have same text");
     STAssertEqualObjects(tweet.source, @"<a href=\"http://www.osfoora.com/mac\" rel=\"nofollow\">Osfoora for Mac</a>", @"Should have same source");
     STAssertNil(tweet.inReplyToStatusIdStr, @"inRepryToStatusIdStr should be null");
-    STAssertEquals(tweet.retweetCount, [NSNumber numberWithInt: 0], @"RetweetCount should be equals to 0");
+    STAssertEquals(tweet.retweetCount, [NSNumber numberWithInteger:0], @"RetweetCount should be equals to 0");
     STAssertFalse(tweet.favorited, @"favorited should be false");
     STAssertFalse(tweet.retweeted, @"favorited should be false");
     STAssertEqualObjects(tweet.createdAt, data, @"CreatedAt should be equals");

--- a/KeyValueObjectMappingTests/NSObject+DCKeyValueObjectMappingTests.m
+++ b/KeyValueObjectMappingTests/NSObject+DCKeyValueObjectMappingTests.m
@@ -97,7 +97,7 @@
     STAssertEqualObjects(tweet.text, @"@pedroh96 cara, comecei uma lib pra iOS, se puder dar uma olhada e/ou contribuir :D KeyValue Parse for Objective-C https://t.co/NWMMc60v", @"Should have same text");
     STAssertEqualObjects(tweet.source, @"<a href=\"http://www.osfoora.com/mac\" rel=\"nofollow\">Osfoora for Mac</a>", @"Should have same source");
     STAssertNil(tweet.inReplyToStatusIdStr, @"inRepryToStatusIdStr should be null");
-    STAssertEquals(tweet.retweetCount, [NSNumber numberWithInt: 0], @"RetweetCount should be equals to 0");
+    STAssertEquals(tweet.retweetCount, [NSNumber numberWithInteger:0], @"RetweetCount should be equals to 0");
     STAssertFalse(tweet.favorited, @"favorited should be false");
     STAssertFalse(tweet.retweeted, @"favorited should be false");
     STAssertEqualObjects(tweet.createdAt, data, @"CreatedAt should be equals");


### PR DESCRIPTION
Added a locale to the parsing configuration which will be used in the
date converter.

By default the NSDateFormatter uses the current locale, which can fail
to read some dates.

In my specific case this happened when the user changed the date to be
displayed with 12 hours instead of 24.
