### PR TITLE
Updated attribute setter that was failing on [NSNull null] value being passed

### DIFF
--- a/DCKeyValueObjectMapping.podspec
+++ b/DCKeyValueObjectMapping.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-  s.name         = "KeyValueObjectMapping"
+  s.name         = "DCKeyValueObjectMapping"
   s.version      = "1.4.0"
   s.summary      = "Automatic KeyValue Object Mapping for Objective-C, parse JSON/plist/Dictionary automatically"
   s.homepage     = "https://github.com/dchohfi/KeyValueObjectMapping"

--- a/KeyValueObjectMapping/DCAttributeSetter.m
+++ b/KeyValueObjectMapping/DCAttributeSetter.m
@@ -11,10 +11,14 @@
 @implementation DCAttributeSetter
 
 + (void)assingValue:(id)value forAttributeName: (NSString *)attributeName andAttributeClass: (Class) attributeClass onObject:(id)object {
+    
+    if ([value isKindOfClass:[NSNull class]]) {
+        
+        value = nil;
+    }
+    
     if([object validateValue:&value forKey:attributeName error:nil]){
-        if([value isKindOfClass:[NSNull class]]){
-            value = nil;
-        }
+        
         if(([value isKindOfClass:[NSNull class]] || value == nil) && attributeClass == [NSString class]){
             [object setValue:nil forKey:attributeName];
         }else {


### PR DESCRIPTION
...assed, and corrected pod spec name.

Web service was returning [NSNull null] values, but these were causing a crash during mapping.
