### PR TITLE
Allow to map an array with a different attribute name than key name

### DIFF
--- a/KeyValueObjectMapping/DCParserConfiguration.m
+++ b/KeyValueObjectMapping/DCParserConfiguration.m
@@ -91,10 +91,9 @@
 - (DCArrayMapping *) arrayMapperForMapper: (DCObjectMapping *) mapper {
     for(DCArrayMapping *arrayMapper in self.arrayMappers){
         DCObjectMapping *mapping = arrayMapper.objectMapping;
-        BOOL sameKey = [mapping.keyReference isEqualToString:mapper.keyReference];
         BOOL sameAttributeName = [mapping.attributeName isEqualToString:mapper.attributeName];
         BOOL sameAttributeNameWithUnderscore = [[self addUnderScoreToPropertyName:mapping.attributeName] isEqualToString:mapper.attributeName];
-        if(sameKey && (sameAttributeName || sameAttributeNameWithUnderscore)){
+        if(sameAttributeName || sameAttributeNameWithUnderscore){
             return arrayMapper;
         }
     }


### PR DESCRIPTION
There are problems if anyone (like me :)) wants to map a json array to a NSArray with different name. I don't understand why this is not allowed right now. This change allows to do it.
