### PR TITLE
Fix for argument naming

### DIFF
--- a/KeyValueObjectMapping/DCNSArrayConverter.m
+++ b/KeyValueObjectMapping/DCNSArrayConverter.m
@@ -70,7 +70,7 @@
     return [NSArray arrayWithArray:valuesHolder];
 }
 
-- (BOOL)canTransformValueForClass:(Class)class {
-    return [class isSubclassOfClass:[NSArray class]];
+- (BOOL)canTransformValueForClass:(Class)cls {
+    return [cls isSubclassOfClass:[NSArray class]];
 }
 @end

--- a/KeyValueObjectMapping/DCNSSetConverter.m
+++ b/KeyValueObjectMapping/DCNSSetConverter.m
@@ -42,8 +42,8 @@
     return [self.arrayConverter serializeValue:value forDynamicAttribute:attribute];
 }
 
-- (BOOL)canTransformValueForClass:(Class)class {
-    return [class isSubclassOfClass:[NSSet class]];
+- (BOOL)canTransformValueForClass:(Class)cls {
+    return [cls isSubclassOfClass:[NSSet class]];
 }
 
 @end

--- a/KeyValueObjectMapping/DCPropertyFinder.m
+++ b/KeyValueObjectMapping/DCPropertyFinder.m
@@ -75,8 +75,8 @@
     return self;
 }
 
-- (NSString *) findPropertyDetailsForKey: (NSString *)key onClass: (Class)class{
-    objc_property_t property = class_getProperty(class, [key UTF8String]);
+- (NSString *) findPropertyDetailsForKey: (NSString *)key onClass: (Class)cls{
+    objc_property_t property = class_getProperty(cls, [key UTF8String]);
     if (property) {
         NSString *attributeDetails = [NSString stringWithUTF8String:property_getAttributes(property)];
         return attributeDetails;

--- a/KeyValueObjectMapping/DCSimpleConverter.m
+++ b/KeyValueObjectMapping/DCSimpleConverter.m
@@ -16,7 +16,7 @@
 -(id)serializeValue:(id)value forDynamicAttribute:(DCDynamicAttribute *)attribute{
     return value;
 }
-- (BOOL)canTransformValueForClass:(Class)class {
+- (BOOL)canTransformValueForClass:(Class)cls {
     return YES;
 }
 


### PR DESCRIPTION
It seems like the argument name `class` is not allowed in Xcode 6.4 so renamed all occurrences.