### PR TITLE
fix crash caused by setting nil to a primitive attribute.

### DIFF
--- a/KeyValueObjectMapping/DCAttributeSetter.m
+++ b/KeyValueObjectMapping/DCAttributeSetter.m
@@ -21,6 +21,8 @@
         
         if(([value isKindOfClass:[NSNull class]] || value == nil) && attributeClass == [NSString class]){
             [object setValue:nil forKey:attributeName];
+        }else if(([value isKindOfClass:[NSNull class]] || value == nil) && attributeClass == nil) {
+            [object setValue:@0 forKey:attributeName];
         }else {
             @try {
                 [object setValue:value forKey:attributeName];


### PR DESCRIPTION
When a wrong value "null" is set to a primitive attribute in the JSON and the DCAttributeSetter try to assign it to the attribute a crash is thrown

Here in this sample JSON book_id in int type and is set to null here I get the crash saying something like that " setNilValueForKey]: could not set nil as the value for the key _book_id.' ":

I fixed it by simply setting @0 to this special case.

{
        "name": "andro",
        "avatar": "http://url/userimage.jpg",
        "summary": "pla pla pla ",
        "book_id": null,
        "datetime": 1455714077
      }
