### PR TITLE
Allow to fill objects of subclasses of "classToGenerate"

### DIFF
--- a/KeyValueObjectMapping/DCKeyValueObjectMapping.m
+++ b/KeyValueObjectMapping/DCKeyValueObjectMapping.m
@@ -82,7 +82,7 @@
     return object;
 }
 - (void) setValuesOnObject: (id) object withDictionary: (NSDictionary *) dictionary {
-    if([object class] != self.classToGenerate){
+    if(![[object class] isSubclassOfClass:self.classToGenerate]){
         return;
     }
     


### PR DESCRIPTION
Instead if checking for equality we now check if the class of the created object is a subclass or equal.

Fixes #80, as Realm uses internal subclasses for models.