### PR TITLE
handle simple values in JSON array responses

### DIFF
--- a/KeyValueObjectMapping/DCKeyValueObjectMapping.m
+++ b/KeyValueObjectMapping/DCKeyValueObjectMapping.m
@@ -58,13 +58,17 @@
         return nil;
     }
     NSMutableArray *values = [[NSMutableArray alloc] initWithCapacity:[array count]];
-    for (id dictionary in array) {
-        if ([dictionary isKindOfClass:[NSNull class]]) {
+    for (id value in array) {
+        if ([value isKindOfClass:[NSNull class]]) {
             continue;
+        } else if ([value isKindOfClass:[NSDictionary class]]) {
+            id parsedValue = [self parseDictionary:value forParentObject:parentObject];
+            [values addObject:parsedValue];
+        } else {
+            [values addObject:value];
         }
-        id value = [self parseDictionary:dictionary forParentObject:parentObject];
-        [values addObject:value];
     }
+    
     return [NSArray arrayWithArray:values];
 }
 


### PR DESCRIPTION
This patch allows simple (non-object) arrays at the top level of the JSON data. Previously KVOM assumed that any top-level array was populated with JSON objects  - i.e. should be parsed as an array of dictionaries.

This allows simple array responses, such as arrays of strings, to be processed correctly.