### PR TITLE
Fixes #92 - check parent object class when looking up DCArrayMapping

### DIFF
--- a/KeyValueObjectMapping/DCNSArrayConverter.m
+++ b/KeyValueObjectMapping/DCNSArrayConverter.m
@@ -42,7 +42,7 @@
     if (primitiveArray) {
         return [self parsePrimitiveValues:values dictionary:dictionary parentObject:parentObject];
     } else {
-        DCArrayMapping *mapper = [self.configuration arrayMapperForMapper:attribute.objectMapping];
+        DCArrayMapping *mapper = [self.configuration arrayMapperForMapper:attribute.objectMapping parentObject:parentObject];
         if (mapper) {
             DCKeyValueObjectMapping *parser = [DCKeyValueObjectMapping mapperForClass:mapper.classForElementsOnArray andConfiguration:self.configuration];
             return [parser parseArray:values forParentObject:parentObject];

--- a/KeyValueObjectMapping/DCParserConfiguration.h
+++ b/KeyValueObjectMapping/DCParserConfiguration.h
@@ -32,5 +32,5 @@
 
 - (id)instantiateObjectForClass:(Class)classOfObjectToGenerate withValues:(NSDictionary *)values;
 - (id)instantiateObjectForClass:(Class)classOfObjectToGenerate withValues:(NSDictionary *)values parentObject:(id)parentObject;
-- (DCArrayMapping *) arrayMapperForMapper: (DCObjectMapping *) mapper;
+- (DCArrayMapping *) arrayMapperForMapper: (DCObjectMapping *) mapper parentObject:(id)parentObject;
 @end

--- a/KeyValueObjectMapping/DCParserConfiguration.m
+++ b/KeyValueObjectMapping/DCParserConfiguration.m
@@ -100,13 +100,14 @@
     }
     return [[classOfObjectToGenerate alloc] init];
 }
-- (DCArrayMapping *) arrayMapperForMapper: (DCObjectMapping *) mapper {
+- (DCArrayMapping *) arrayMapperForMapper: (DCObjectMapping *) mapper parentObject:(id)parentObject {
     for(DCArrayMapping *arrayMapper in self.arrayMappers){
         DCObjectMapping *mapping = arrayMapper.objectMapping;
+        BOOL sameClass = [parentObject class] == mapping.classReference;
         BOOL sameKey = [mapping.keyReference isEqualToString:mapper.keyReference];
         BOOL sameAttributeName = [mapping.attributeName isEqualToString:mapper.attributeName];
         BOOL sameAttributeNameWithUnderscore = [[self addUnderScoreToPropertyName:mapping.attributeName] isEqualToString:mapper.attributeName];
-        if(sameKey && (sameAttributeName || sameAttributeNameWithUnderscore)){
+        if(sameClass && sameKey && (sameAttributeName || sameAttributeNameWithUnderscore)){
             return arrayMapper;
         }
     }


### PR DESCRIPTION
This fixes https://github.com/dchohfi/KeyValueObjectMapping/issues/92

If you have more than one DCArrayMapping implementation which uses the same key/attribute names, without this patch its pot luck which one you will get at runtime (likely the first one added).

This patch enforces a check to ensure the array mapper is one added for the parent object class of the array field being mapped.

(Repost of earlier PR: https://github.com/dchohfi/KeyValueObjectMapping/pull/93 - closed due to branch finagling)